### PR TITLE
Only add the end block padding at the end of the blocks

### DIFF
--- a/org-padding.el
+++ b/org-padding.el
@@ -74,7 +74,10 @@ and CDR represents bottom org-block-end-line padding")
              (2 (let* ((line-type (downcase (match-string 1)))
                        (padding (if (string= "+begin" line-type)
                                   org-padding-block-begin-line-padding
-                                  org-padding-block-end-line-padding)))
+                                  (if (string= "+end" line-type)
+                                      org-padding-block-end-line-padding
+                                    nil)
+                                  )))
                   (org-padding--set-padding (match-beginning 2) padding)
                   nil))))))
     (if org-padding-mode


### PR DESCRIPTION
The current code adds padding after every comment line and, by reading the code, it is not even clear that this was the original intention. The new code just adds padding at the end of blocks.